### PR TITLE
[ADD] detection_mode-driven tracker

### DIFF
--- a/multiple_sensor_person_tracking/src/multiple_sensor_person_tracker_component.cpp
+++ b/multiple_sensor_person_tracking/src/multiple_sensor_person_tracker_component.cpp
@@ -42,6 +42,11 @@ namespace multiple_sensor_person_tracking {
     enum Status {
         NO_EXISTS = 0, EXISTS_LEG, EXISTS_BODY, EXISTS_LEG_AND_BODY
     };
+    enum class DetectionMode {
+        LEG,
+        BODY,
+        BODY_LEG
+    };
 
     class PersonTracker : public rclcpp::Node {
         private:
@@ -86,6 +91,7 @@ namespace multiple_sensor_person_tracking {
             double attention_leg_time_;
             unsigned int attention_leg_idx_;
             bool merge_nontravelable_region_;
+            DetectionMode detection_mode_;
 
             visualization_msgs::msg::Marker makeLegPoseMarker( const std::vector<geometry_msgs::msg::Pose>& leg_poses );
             visualization_msgs::msg::Marker makeLegAreaMarker( const std::vector<geometry_msgs::msg::Pose>& leg_poses );
@@ -401,6 +407,12 @@ void multiple_sensor_person_tracking::PersonTracker::nontravelableRegionCallback
 void multiple_sensor_person_tracking::PersonTracker::dr_spaam_callback(const geometry_msgs::msg::PoseArray::ConstSharedPtr &dr_spaam_msg) 
 {
     dr_spaam_msg_ = dr_spaam_msg;
+    if (detection_mode_ == DetectionMode::LEG) {
+        auto empty_ssd_msg = std::make_shared<vision_msgs::msg::Detection3DArray>();
+        empty_ssd_msg->header.stamp = dr_spaam_msg->header.stamp;
+        empty_ssd_msg->header.frame_id = target_frame_;
+        callbackPoseArray(empty_ssd_msg);
+    }
 }
 
 void multiple_sensor_person_tracking::PersonTracker::callbackPoseArray ( const vision_msgs::msg::Detection3DArray::ConstSharedPtr &ssd_msg ) {
@@ -411,9 +423,11 @@ void multiple_sensor_person_tracking::PersonTracker::callbackPoseArray ( const v
     sensor_msgs::msg::PointCloud2 cloud_scan_msg;
     Eigen::Vector4f estimated_value( 0.0, 0.0, 0.0, 0.0 );
 
-    rclcpp::Time current_time(dr_spaam_msg_->header.stamp);
+    rclcpp::Time current_time = this->get_clock()->now();
     double dt = (current_time - previous_time_).seconds();
     previous_time_ = current_time;
+    const bool use_leg_detection = detection_mode_ != DetectionMode::BODY;
+    const bool use_body_detection = detection_mode_ != DetectionMode::LEG;
 
     // Sensor data to TF2 conversion
     try {
@@ -430,8 +444,8 @@ void multiple_sensor_person_tracking::PersonTracker::callbackPoseArray ( const v
         return;
     }
 
-    if ( !exists_target_ && ssd_msg->detections.size() == 0) {
-        if ( dr_spaam_msg_->poses.size() == 0 ) {
+    if ( !exists_target_ && use_body_detection && ssd_msg->detections.size() == 0) {
+        if ( !use_leg_detection || dr_spaam_msg_->poses.size() == 0 ) {
             RCLCPP_ERROR(this->get_logger(), "Result :          NO_EXISTS (DR-SPAAM)" );
             exists_target_ = false;
             following_position_->pose.position.x = 0.0;
@@ -489,7 +503,11 @@ void multiple_sensor_person_tracking::PersonTracker::callbackPoseArray ( const v
 
     // Searching for observables to input to the Kalman filter
     Eigen::Vector2f leg_observed_value, body_observed_value;
-    int result = findTwoObservationValue( dr_spaam_msg_->poses, body_detections_in_target, &leg_observed_value, &body_observed_value );
+    const std::vector<geometry_msgs::msg::Pose> leg_observations =
+        use_leg_detection ? dr_spaam_msg_->poses : std::vector<geometry_msgs::msg::Pose>{};
+    const std::vector<vision_msgs::msg::Detection3D> body_observations =
+        use_body_detection ? body_detections_in_target : std::vector<vision_msgs::msg::Detection3D>{};
+    int result = findTwoObservationValue( leg_observations, body_observations, &leg_observed_value, &body_observed_value );
     if ( result == Status::NO_EXISTS ) {
         if ( no_exists_time_ == -1.0 ) no_exists_time_ = this->get_clock()->now().seconds();
         else if ( this->get_clock()->now().seconds() - no_exists_time_ >= target_change_tolerance_ ){
@@ -503,20 +521,31 @@ void multiple_sensor_person_tracking::PersonTracker::callbackPoseArray ( const v
     } else no_exists_time_ = -1.0;
 
     // Tracking by Kalman Filter
-    if ( ( !exists_target_ && result == Status::EXISTS_LEG_AND_BODY) || (!exists_target_ && result == Status::EXISTS_BODY) ) {
-        kf_->init( body_observed_value );
-        estimated_value[0] = body_observed_value[0];
-        estimated_value[1] = body_observed_value[1];
-        exists_target_ = true;
-    } else if ( !exists_target_ && result != EXISTS_LEG_AND_BODY ) {
-        RCLCPP_ERROR(this->get_logger(), "Result :          NO_EXISTS" );
-        exists_target_ = false;
-        following_position_->pose.position.x = 0.0;
-        following_position_->pose.position.y = 0.0;
-        following_position_->status = Status::NO_EXISTS;
-        pub_following_position_->publish( *following_position_ );
-        return;
-    }else {
+    if ( !exists_target_ ) {
+        if ( result == Status::EXISTS_BODY || result == Status::EXISTS_LEG_AND_BODY ) {
+            kf_->init( body_observed_value );
+            estimated_value[0] = body_observed_value[0];
+            estimated_value[1] = body_observed_value[1];
+            following_position_->rotation_position.x = body_observed_value[0];
+            following_position_->rotation_position.y = body_observed_value[1];
+            exists_target_ = true;
+        } else if ( result == Status::EXISTS_LEG ) {
+            kf_->init( leg_observed_value );
+            estimated_value[0] = leg_observed_value[0];
+            estimated_value[1] = leg_observed_value[1];
+            following_position_->rotation_position.x = leg_observed_value[0];
+            following_position_->rotation_position.y = leg_observed_value[1];
+            exists_target_ = true;
+        } else {
+            RCLCPP_ERROR(this->get_logger(), "Result :          NO_EXISTS" );
+            exists_target_ = false;
+            following_position_->pose.position.x = 0.0;
+            following_position_->pose.position.y = 0.0;
+            following_position_->status = Status::NO_EXISTS;
+            pub_following_position_->publish( *following_position_ );
+            return;
+        }
+    } else {
         if( result == Status::EXISTS_LEG ) {
             kf_->compute( dt, leg_observed_value, &estimated_value );
             following_position_->rotation_position.x = estimated_value[0];
@@ -591,6 +620,7 @@ void multiple_sensor_person_tracking::PersonTracker::onInit() {
     this->declare_parameter<std::string>("ssd_topic_name", "/ssd_ros/object_3d_poses");
     this->declare_parameter<std::string>("target_frame", "base_footprint");
     this->declare_parameter<std::string>("odom_frame_name", "odom");
+    this->declare_parameter<std::string>("detection_mode", "body_leg");
     this->declare_parameter<bool>("merge_nontravelable_region", false);
     this->declare_parameter<double>("leg_tracking_range", 2.5);
     this->declare_parameter<double>("body_tracking_range", 2.5);
@@ -608,11 +638,27 @@ void multiple_sensor_person_tracking::PersonTracker::onInit() {
     auto ssd_topic_name = this->get_parameter("ssd_topic_name").as_string();
     target_frame_ = this->get_parameter("target_frame").as_string();
     odom_frame_name_ = this->get_parameter("odom_frame_name").as_string();
+    auto detection_mode = this->get_parameter("detection_mode").as_string();
     merge_nontravelable_region_ = this->get_parameter("merge_nontravelable_region").as_bool();
     leg_tracking_range_ = this->get_parameter("leg_tracking_range").as_double();
     body_tracking_range_ = this->get_parameter("body_tracking_range").as_double();
     target_change_tolerance_ = this->get_parameter("target_change_tolerance").as_double();
     display_marker_ = this->get_parameter("display_marker").as_bool();
+    if (detection_mode == "leg") {
+        detection_mode_ = DetectionMode::LEG;
+    } else if (detection_mode == "body") {
+        detection_mode_ = DetectionMode::BODY;
+    } else if (detection_mode == "body_leg") {
+        detection_mode_ = DetectionMode::BODY_LEG;
+    } else {
+        RCLCPP_WARN(
+            this->get_logger(),
+            "Unknown detection_mode '%s'. Falling back to 'body_leg'.",
+            detection_mode.c_str());
+        detection_mode_ = DetectionMode::BODY_LEG;
+        detection_mode = "body_leg";
+    }
+    RCLCPP_INFO(this->get_logger(), "detection_mode: %s", detection_mode.c_str());
 
     // Initialize class members
     tf_sub_.reset(new tf2_ros::TransformListener(tfBuffer_));

--- a/sobit_follower/README.en.md
+++ b/sobit_follower/README.en.md
@@ -98,6 +98,15 @@ $ roslaunch sobit_follower sobit_pro_follower_me.launch rviz:=false rqt_reconfig
 ```
 ※To activate SOBIT PRO, RGB-D sensor, and 2D LiDAR
 
+### [sobit_follower.launch.py](launch/sobit_follower.launch.py) (ROS2)
+- Integrated launch file for ROS2
+- path：`sobit_follower/launch/sobit_follower.launch.py`
+```bash
+$ ros2 launch sobit_follower sobit_follower.launch.py robot_type:=hsrb
+# Arguments
+# robot_type : hsrb / sobit_pro / sobit_edu
+```
+
 ## Configuration
 ### tracker.launch.xml
 - #### [sobit_edu_tracker.launch.xml](launch/include/sobit_edu/sobit_edu_tracker.launch.xml)
@@ -128,6 +137,7 @@ $ roslaunch sobit_follower sobit_pro_follower_me.launch rviz:=false rqt_reconfig
 |/scan_topic_name|string|Scan Topic Name|
 |/dr_spaam_topic_name|string|DR-SPAAM Topic Name|
 |/ssd_topic_name|string|SSD Topic Name|
+|/detection_mode|string|Detection mode (`body` / `leg` / `body_leg`)|
 |/target_frame|string|Reference Frame Name|
 |/merge_nontravelable_region|bool|Enables or disables the functionality for avoiding small obstacles by segmentation|
 |/target_range|double|Maximum range when determining the tracking target[m]|
@@ -360,6 +370,8 @@ G(v,ω) = α * heading(v,ω) + β * obstacle(v,ω) + γ * linear(v,ω) + δ * an
 - [x] OSS
     - [x] Improved documentation
     - [x] Unified coding style
+- [x] Added `detection_mode` support (`body` / `leg` / `body_leg`)
+    - [x] Conditional detector launch (SSD / DR-SPAAM) based on `detection_mode` in `tracker_param.yaml`
 
 
 See the [open issues ][license-url] for a full list of proposed features (and known issues).

--- a/sobit_follower/README.md
+++ b/sobit_follower/README.md
@@ -98,6 +98,15 @@ $ roslaunch sobit_follower sobit_pro_follower_me_id.launch rviz:=false rqt_recon
 ```
 ※SOBIT PRO，RGB-Dセンサ，2D LiDARの起動をすること
 
+### [sobit_follower.launch.py](launch/sobit_follower.launch.py) (ROS2)
+- ROS2用の統合Launch
+- path：`sobit_follower/launch/sobit_follower.launch.py`
+```bash
+$ ros2 launch sobit_follower sobit_follower.launch.py robot_type:=hsrb
+# 引数
+# robot_type : hsrb / sobit_pro / sobit_edu
+```
+
 
 ## 構成
 ### tracker.launch.xml
@@ -129,6 +138,7 @@ $ roslaunch sobit_follower sobit_pro_follower_me_id.launch rviz:=false rqt_recon
 |/scan_topic_name|string|Scanのトピック名|
 |/dr_spaam_topic_name|string|DR-SPAAMのトピック名|
 |/ssd_topic_name|string|SSDのトピック名|
+|/detection_mode|string|検出モード (`body` / `leg` / `body_leg`)|
 |/target_frame|string|基準フレーム名|
 |/merge_nontravelable_region|bool|セグメンテーションによる小さな障害物回避機能を有効するか|
 |/target_range|double|追跡対象を決定するときの最大範囲[m]|
@@ -361,6 +371,8 @@ G(v,ω) = α * heading(v,ω) + β * obstacle(v,ω) + γ * linear(v,ω) + δ * an
 - [x] OSS
     - [x] ドキュメンテーションの充実
     - [x] コーディングスタイルの統一
+- [x] `detection_mode`（`body` / `leg` / `body_leg`）に対応
+    - [x] `tracker_param.yaml` の `detection_mode` に応じた検出器の条件起動（SSD / DR-SPAAM）
 
 現時点のバッグや新規機能の依頼を確認するために[Issueページ][license-url] をご覧ください．
 

--- a/sobit_follower/launch/sobit_follower.launch.py
+++ b/sobit_follower/launch/sobit_follower.launch.py
@@ -1,16 +1,30 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import ComposableNodeContainer, Node
 from launch_ros.descriptions import ComposableNode
-from ament_index_python.packages import get_package_share_directory
-import os
+import yaml
 
-def generate_launch_description():
 
+def _load_detection_mode(params_path: str) -> str:
+    detection_mode = "body_leg"
+    try:
+        with open(params_path, "r", encoding="utf-8") as f:
+            params = yaml.safe_load(f) or {}
+        detection_mode = params.get("/**", {}).get("ros__parameters", {}).get("detection_mode", detection_mode)
+    except Exception:
+        return detection_mode
+
+    detection_mode = str(detection_mode).strip().lower()
+    if detection_mode not in ("body", "leg", "body_leg"):
+        detection_mode = "body_leg"
+    return detection_mode
+
+
+def _launch_setup(context):
     sobit_follower_share = FindPackageShare("sobit_follower")
 
     robot_type = LaunchConfiguration("robot_type")
@@ -20,13 +34,109 @@ def generate_launch_description():
     sensor_rotator_params = LaunchConfiguration("sensor_rotator_params")
     person_following_control_params = LaunchConfiguration("person_following_control_params")
 
+    tracker_params_path = person_tracker_params.perform(context)
+    detection_mode = _load_detection_mode(tracker_params_path)
+
+    dr_spaam_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                sobit_follower_share,
+                "launch",
+                "include",
+                "dr_spaam_ros.launch.py",
+            ])
+        ),
+        launch_arguments={
+            "robot_type": robot_type,
+            "params_file": PathJoinSubstitution([
+                sobit_follower_share,
+                "param",
+                robot_type,
+                "dr_spaam_param.yaml",
+            ]),
+        }.items(),
+    )
+
+    ssd_ros_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                sobit_follower_share,
+                "launch",
+                "include",
+                "ssd_pose_ros.launch.py",
+            ])
+        ),
+        launch_arguments={
+            "robot_type": robot_type,
+            "params_file": PathJoinSubstitution([
+                sobit_follower_share,
+                "param",
+                robot_type,
+                "ssd_param.yaml",
+            ]),
+        }.items(),
+    )
+
+    sobits_follower = ComposableNodeContainer(
+        name="sobit_follower_container",
+        namespace="sobit_follower",
+        package="rclcpp_components",
+        executable="component_container_mt",
+        output="screen",
+        composable_node_descriptions=[
+            ComposableNode(
+                package="multiple_sensor_person_tracking",
+                plugin="multiple_sensor_person_tracking::PersonTracker",
+                name="person_tracker",
+                namespace="sobit_follower",
+                parameters=[person_tracker_params],
+            ),
+            ComposableNode(
+                package="multiple_sensor_person_tracking",
+                plugin="multiple_sensor_person_tracking::PersonAimSensorRotator",
+                name="person_aim_sensor_rotator",
+                namespace="sobit_follower",
+                parameters=[sensor_rotator_params],
+            ),
+            ComposableNode(
+                package="person_following_control",
+                plugin="person_following_control::PersonFollowing",
+                name="person_following_control",
+                namespace="sobit_follower",
+                parameters=[person_following_control_params],
+            ),
+        ],
+    )
+
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="screen",
+        arguments=["-d", rviz_cfg],
+        condition=IfCondition(use_rviz),
+    )
+
+    actions = [rviz_node]
+    if detection_mode != "body":
+        actions.append(dr_spaam_launch)
+    if detection_mode != "leg":
+        actions.append(ssd_ros_launch)
+    actions.append(sobits_follower)
+    return actions
+
+def generate_launch_description():
+    sobit_follower_share = FindPackageShare("sobit_follower")
+
+    robot_type = LaunchConfiguration("robot_type")
+
     launch_args = [
         DeclareLaunchArgument(
             "robot_type",
             description="Type of the robot",
             # default_value="sobit_edu",
-            default_value="sobit_pro",
-            # default_value="hsrb",
+            # default_value="sobit_pro",
+            default_value="hsrb",
         ), 
         DeclareLaunchArgument(
             "use_rviz", 
@@ -79,97 +189,4 @@ def generate_launch_description():
             ])
         ),
     ]
-
-    # DR-SPAAM launch includes
-    dr_spaam_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            PathJoinSubstitution([
-                sobit_follower_share, 
-                "launch", 
-                "include",
-                "dr_spaam_ros.launch.py"])
-        ),
-        launch_arguments={
-            "robot_type": robot_type,
-            "params_file": PathJoinSubstitution([
-                sobit_follower_share,
-                "param",
-                robot_type,
-                "dr_spaam_param.yaml",
-            ]),
-        }.items(),
-    )
-
-    # SSD launch includes
-    ssd_ros_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            PathJoinSubstitution([
-                sobit_follower_share,
-                "launch",
-                "include",
-                "ssd_pose_ros.launch.py",
-            ])
-        ),
-        launch_arguments={
-            'robot_type': robot_type,
-            'params_file': PathJoinSubstitution([
-                sobit_follower_share,
-                "param",
-                robot_type,
-                "ssd_param.yaml",
-            ]),
-        }.items()
-    )
-
-    # Component Container
-    sobits_follower = ComposableNodeContainer(
-        name="sobit_follower_container",
-        namespace="sobit_follower",
-        package="rclcpp_components",
-        executable="component_container_mt",
-        output="screen",
-        composable_node_descriptions=[
-            # Tracker Component
-            ComposableNode(
-                package="multiple_sensor_person_tracking",
-                plugin="multiple_sensor_person_tracking::PersonTracker",
-                name="person_tracker",
-                namespace="sobit_follower",
-                parameters=[person_tracker_params],
-            ),
-            # Sensor Rotator Component
-            ComposableNode(
-                package="multiple_sensor_person_tracking",
-                plugin="multiple_sensor_person_tracking::PersonAimSensorRotator",
-                name="person_aim_sensor_rotator",
-                namespace="sobit_follower",
-                parameters=[sensor_rotator_params],
-            ),
-            # Following Control Component
-            ComposableNode(
-                package="person_following_control",
-                plugin="person_following_control::PersonFollowing",
-                name="person_following_control",
-                namespace="sobit_follower",
-                parameters=[person_following_control_params],
-            ),
-        ]
-    )
-
-    rviz_node = Node(
-        package='rviz2',
-        executable='rviz2',
-        name='rviz2',
-        output='screen',
-        arguments=['-d', rviz_cfg],
-        condition=IfCondition(use_rviz)
-    )
-
-    return LaunchDescription(
-        launch_args + [
-            rviz_node,
-            ssd_ros_launch,
-            dr_spaam_launch,
-            sobits_follower,
-        ]
-    )
+    return LaunchDescription(launch_args + [OpaqueFunction(function=_launch_setup)])

--- a/sobit_follower/param/hsrb/tracker_param.yaml
+++ b/sobit_follower/param/hsrb/tracker_param.yaml
@@ -3,6 +3,7 @@
     # Topic & Frame
     dr_spaam_topic_name : /dr_spaam_detections
     ssd_topic_name : /ssd_ros/object_3d_poses
+    detection_mode : body_leg                   # body_leg or body or leg 
     target_frame : base_footprint
 
     # Merging Point Cloud Non-travelable region (true) or Not merging (false)

--- a/sobit_follower/param/sobit_edu/tracker_param.yaml
+++ b/sobit_follower/param/sobit_edu/tracker_param.yaml
@@ -4,6 +4,7 @@
     scan_topic_name : /sobit_edu/scan
     dr_spaam_topic_name : /dr_spaam_detections
     ssd_topic_name : /ssd_ros/object_3d_poses
+    detection_mode : body_leg                   # body_leg or body or leg 
     target_frame : sobit_edu/base_footprint
     odom_frame_name : sobit_edu/odom
 

--- a/sobit_follower/param/sobit_pro/tracker_param.yaml
+++ b/sobit_follower/param/sobit_pro/tracker_param.yaml
@@ -4,6 +4,7 @@
     scan_topic_name : /sobit_pro/scan
     dr_spaam_topic_name : /dr_spaam_detections
     ssd_topic_name : /ssd_ros/object_3d_poses
+    detection_mode : body_leg                   # body_leg or body or leg 
     target_frame : sobit_pro/base_footprint
     odom_frame_name : sobit_pro/odom
 


### PR DESCRIPTION
## Summary
This PR adds `detection_mode` support to `sobit_follower` and updates launch behavior/docs accordingly.

`detection_mode` supports:
- `body`
- `leg`
- `body_leg`

## Motivation
Previously, tracking assumed merged body+leg detection and always required both detector pipelines.
This change allows running only the necessary detector for each use case and robot setup.

## Changes
### Tracker
- Added `detection_mode` parameter to `multiple_sensor_person_tracker_component.cpp`.
- Added mode-specific tracking behavior:
  - `body`: body-only tracking
  - `leg`: leg-only tracking
  - `body_leg`: fused tracking (existing behavior)
- Updated processing to work even when unused detector topics are not present.
- In `leg` mode, tracking is triggered from DR-SPAAM callback (since SSD is not launched).
- Updated `dt` calculation to use node clock (`now`) for robustness.

### Launch
- Updated `sobit_follower.launch.py`:
  - Detector launch is conditional based on `detection_mode` in `tracker_param.yaml`:
    - `body` -> launch SSD only
    - `leg` -> launch DR-SPAAM only
    - `body_leg` -> launch both
  - Removed `detection_mode` as launch argument.
- Updated RViz config selection pattern:
  - `sobit_follower_sobit_<robot_type>.rviz`

### Parameters
- Added `detection_mode: body_leg` to tracker parameter files:
  - `param/hsrb/tracker_param.yaml`
  - `param/sobit_pro/tracker_param.yaml`
  - `param/sobit_edu/tracker_param.yaml`

### Documentation
- Updated `README.md` and `README.en.md`:
  - Added ROS2 launch usage details
  - Documented `detection_mode`
  - Clarified that `detection_mode` is read from `tracker_param.yaml`
  - Added milestone entries for this feature

## Verification
- Built and verified:
  - `multiple_sensor_person_tracking`
  - `sobit_follower`
- Confirmed:
  - `body` mode works without DR-SPAAM
  - `leg` mode works without SSD
  - `body_leg` keeps fused behavior

## Notes
- Default behavior remains `body_leg` to preserve compatibility.
